### PR TITLE
Return early from getLongestTransitionOrAnimationTime if undefined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,10 +28,13 @@ var getLongestTransitionOrAnimationTime = function( el ){
     var delay, duration, subTotals;
 
     delay = getComputedStyle( el )[compat.prefixed(cssType + "Delay")]
+    if (!delay) {
+      return [0];
+    }
     delay = delay.split(',').map(parseFloat);
     duration = getComputedStyle( el )[compat.prefixed(cssType + "Duration")]
     duration = duration.split(',').map(parseFloat);
-  
+
     subTotals = delay.map(function(d, ix) { return d + duration[ix] });
     return totals.concat(subTotals);
 


### PR DESCRIPTION
IE8 doesn't seem to support getting the computed style of a property it doesn't support so attempts to .split/map on undefined - which of course breaks. This fixes the issue - might be a more elegant fix though? Or I might be misunderstanding the fallback API...
