### PR TITLE
Test for css transitions in doTransition fallback conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In this example, we have a funky modal we want to animate in with some excessive
 effects. We want to make sure the animation is timed based on the transition
 that will take the longest, in this case it's the transformation.
 
-On calling doTransition, CSSDriven will: 
+On calling doTransition, CSSDriven will:
 
 - Run the "setup" instruction - add the class `is-animating`
 - Measure all transition and animation durations + delays to find the longest
@@ -129,6 +129,22 @@ Because the transition doesn't actually occur on the accordion where we're
 changing the classes, we've added an option at the end, `"timingElement"` lets
 us set a different element to measure the transition/animation timing on.
 
+## Browser Support
+
+css-driven aims to technically support IE8+ - but perform best in modern
+browsers. Obviously browsers that do not support CSS transitions cannot transition
+so this is detected we fallback to run each of the steps in sequence which more
+often than not is more than acceptable.
+
+### IE8/9 required polyfills
+We do use some more modern Javscript features so you will need to polyfill
+the following for the css-driven to run in older browsers (IE8/9).
+
+- (Object.keys)[https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Polyfill]
+- (Array.forEach)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Polyfill]
+- (Element.classList)[https://developer.mozilla.org/en/docs/Web/API/Element/classList#JavaScript_shim_for_other_implementations]
+- (Array.isArray)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill]
+
 ## Method Reference
 
 ### doTransition(domElement, instructions, options)
@@ -158,7 +174,8 @@ _not available in minified version_
 
 Set the fallback mode to be true or false. When in fallback mode, CSS Driven
 will always act as if requestAnimationFrame is not available, and run either
-your fallback function, or all the steps in sequence synchronously.
+your fallback function, or all the steps in sequence synchronously. Useful so you
+can write your doTransition fallback functions in modern browsers.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ the following for the css-driven to run in older browsers (IE8/9).
 - (Array.forEach)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Polyfill]
 - (Element.classList)[https://developer.mozilla.org/en/docs/Web/API/Element/classList#JavaScript_shim_for_other_implementations]
 - (Array.isArray)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill]
+- (console.log)[https://github.com/paulmillr/console-polyfill] - only if you wish to use CSSDriven.debugMode() or CSSDriven.fallbackMode() debug inside IE8
 
 ## Method Reference
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ often than not is more than acceptable.
 We do use some more modern Javscript features so you will need to polyfill
 the following for the css-driven to run in older browsers (IE8/9).
 
-- (Object.keys)[https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Polyfill]
-- (Array.forEach)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Polyfill]
-- (Element.classList)[https://developer.mozilla.org/en/docs/Web/API/Element/classList#JavaScript_shim_for_other_implementations]
-- (Array.isArray)[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill]
-- (console.log)[https://github.com/paulmillr/console-polyfill] - only if you wish to use CSSDriven.debugMode() or CSSDriven.fallbackMode() debug inside IE8
+- [Object.keys](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Polyfill)
+- [Array.forEach](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Polyfill)
+- [Element.classList](https://developer.mozilla.org/en/docs/Web/API/Element/classList#JavaScript_shim_for_other_implementations)
+- [Array.isArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill)
+- [console.log](https://github.com/paulmillr/console-polyfill) - only if you wish to use CSSDriven.debugMode() or CSSDriven.fallbackMode() debug inside IE8
 
 ## Method Reference
 

--- a/src/compat.js
+++ b/src/compat.js
@@ -53,7 +53,7 @@ var Modernizr = (function( window, document, undefined ) {
       };
     }
     else {
-      hasOwnProp = function (object, property) { 
+      hasOwnProp = function (object, property) {
         return ((property in object) && is(object.constructor.prototype[property], 'undefined'));
       };
     }
@@ -165,7 +165,19 @@ var Modernizr = (function( window, document, undefined ) {
         }
     }
 
+    tests['csstransitions'] = function() {
+        return testPropsAll('transition');
+    };
 
+    for ( var feature in tests ) {
+        if ( hasOwnProp(tests, feature) ) {
+            // run the test, throw the return value into the Modernizr,
+            //   then based on that boolean, define an appropriate className
+            //   and push it into an array of classes we'll join later.
+            featureName  = feature.toLowerCase();
+            Modernizr[featureName] = tests[feature]();
+        }
+    }
 
      Modernizr.addTest = function ( feature, test ) {
        if ( typeof feature == 'object' ) {
@@ -191,7 +203,7 @@ var Modernizr = (function( window, document, undefined ) {
 
        }
 
-       return Modernizr; 
+       return Modernizr;
      };
 
 
@@ -244,6 +256,7 @@ if (!requestAnimationFrame) {
   cancelAnimationFrame = window.cancelAnimationFrame;
 }
 
+module.exports.cssTransition = Modernizr.csstransitions;
 module.exports.requestAnimationFrame = requestAnimationFrame;
 module.exports.cancelAnimationFrame = cancelAnimationFrame;
 module.exports.prefixed = function(prop, obj, elem) {

--- a/src/core.js
+++ b/src/core.js
@@ -56,14 +56,14 @@ var doTransition = function($el, instructions, options) {
   Object.keys(instructions).forEach(function(key) {
     processed[key] = instructions[key];
   });
-    
+
   var animData = {state: null};
   if (process.env.NODE_ENV !== "production") {
     animData.name = options["name"] || "anim" + animNameIncrement++;
   }
 
   var timingElem = options["timingElement"] || $el;
-  
+
   Object.keys(verbMap).forEach(function(verb) {
     var procInst = processed[verb]
     if (procInst) {
@@ -85,7 +85,7 @@ var doTransition = function($el, instructions, options) {
     }
   }
 
-  if (!compat.requestAnimationFrame) {
+  if (!compat.requestAnimationFrame || !compat.cssTransition) {
     return doFallback($el, processed, animData, options);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,10 +28,13 @@ var getLongestTransitionOrAnimationTime = function( el ){
     var delay, duration, subTotals;
 
     delay = getComputedStyle( el )[compat.prefixed(cssType + "Delay")]
+    if (!delay) {
+      return [0];
+    }
     delay = delay.split(',').map(parseFloat);
     duration = getComputedStyle( el )[compat.prefixed(cssType + "Duration")]
     duration = duration.split(',').map(parseFloat);
-  
+
     subTotals = delay.map(function(d, ix) { return d + duration[ix] });
     return totals.concat(subTotals);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,9 +28,6 @@ var getLongestTransitionOrAnimationTime = function( el ){
     var delay, duration, subTotals;
 
     delay = getComputedStyle( el )[compat.prefixed(cssType + "Delay")]
-    if (!delay) {
-      return [0];
-    }
     delay = delay.split(',').map(parseFloat);
     duration = getComputedStyle( el )[compat.prefixed(cssType + "Duration")]
     duration = duration.split(',').map(parseFloat);


### PR DESCRIPTION
The test currently used to invoke callback mode is failing for me in IE8 because I polyfill RAF for other libraries we are using. Those libraries work fine in IE8 with the RAF polyfill (in one case ScrollMagic and another D3.js). Polyfilling RAF is pretty common. This PR would close #3.

Seeing as you already have most of the infrastructure to add this test and conceptually the fallback exists - it feels logical to put it css-driven core instead of putting it in the hands of the developer to wrap all calls to doTransition in an if..else.

I've also added some notes to the readme about browser support and the polyfills required to have css-driven work in IE8+.

I've tested this in IE8 and it works really well and as expected. Testing in IE8 did mean adding all the polyfills I mention in the readme to the app.js - which I have not included in this PR.
